### PR TITLE
Fix: Check node type before extracting variable names.

### DIFF
--- a/injector/NodeExtractor.py
+++ b/injector/NodeExtractor.py
@@ -12,6 +12,7 @@ class NodeExtractor():
     """
     def __init__(self, node):
         self.lineno = node.lineno
+        self.vars = []
 
         if 'body' in node._fields:
             if isinstance(node, ast.FunctionDef):
@@ -29,7 +30,9 @@ class NodeExtractor():
         """
         module = ast.Module(body=[self.astNode], type_ignores=[])
         self.syntax = ast.unparse(ast.fix_missing_locations((module)))
-        self.vars = CollectVariableNames(self.astNode).var_names 
+
+        if isinstance(self.astNode, (ast.Assign, ast.AnnAssign)):
+            self.vars = CollectVariableNames(self.astNode).var_names 
             
     def getEmptyASTRootNode(self,node):
         """

--- a/injector/NodeExtractor.py
+++ b/injector/NodeExtractor.py
@@ -11,6 +11,7 @@ class NodeExtractor():
         be extended to support variables.
     """
     def __init__(self, node):
+        self.VARIABLE_NODE_TYPES = (ast.Assign, ast.AnnAssign)
         self.lineno = node.lineno
         self.vars = []
 
@@ -31,7 +32,7 @@ class NodeExtractor():
         module = ast.Module(body=[self.astNode], type_ignores=[])
         self.syntax = ast.unparse(ast.fix_missing_locations((module)))
 
-        if isinstance(self.astNode, (ast.Assign, ast.AnnAssign)):
+        if isinstance(self.astNode, self.VARIABLE_NODE_TYPES):
             self.vars = CollectVariableNames(self.astNode).var_names 
             
     def getEmptyASTRootNode(self,node):


### PR DESCRIPTION
This PR adds a check to see if a node is of type Assign or AnnAssign before extracting variable names. This fix is being pushed separately because not having this check will cause errors. In the coming PR, I will be adding support for other types of nodes which can be evaluated for variable names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced variable extraction logic in the code analysis process.
	- Refined conditions for collecting variable names during AST node processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->