### PR TITLE
Add feature to log start and end of unique trace with the provided variable value as the unique id.

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -169,11 +169,13 @@ class LogInjector(ast.NodeTransformer):
         return self.injectLogTypesA(node)
 
     def visit_Expr(self, node):
+        # Save disabled variables.
         if (self.funcId == 0):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
             self.disabledVariables += getDisabledVariables(node)
 
+        # Replace traceid comments with log statements.
         traceVar = getTraceId(node)
         if (traceVar):
             return getTraceIdLogStmt(traceVar["type"], traceVar["variable"])

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,17 +1,21 @@
 import ast
-from injector.CollectVariableInfo import CollectAssignVarInfo, CollectFunctionArgInfo, CollectVariableDefault
 from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getDisabledVariables
+from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
+from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
+from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
+from injector.VariableCollectors.CollectFunctionArgInfo import CollectFunctionArgInfo
 
 class LogInjector(ast.NodeTransformer):
-    def __init__(self, node, ltMap, varMap, logTypeCount):
+    def __init__(self, node, ltMap, logTypeCount):
         self.ltMap = ltMap
-        self.varMap = varMap
+        self.varMap = {}
         self.logTypeCount = logTypeCount
         self.funcId = 0
 
         self.globalsInFunc = []
         self.globalDisabledVariables = []
-        self.disabledVariables = []
+        self.localDisabledVariables = []
+        self.nodeVarInfo = []
 
         self.minLogTypeCount = self.logTypeCount
         self.generic_visit(node)
@@ -37,7 +41,7 @@ class LogInjector(ast.NodeTransformer):
 
         return getLtLogStmt(self.logTypeCount)
     
-    def generateVarLogStmts(self, varInfo):
+    def generateVarLogStmts(self):
         '''
             This function generates logging statements for all the variables.
             An assign statement is created for temporary variables before logging
@@ -46,13 +50,13 @@ class LogInjector(ast.NodeTransformer):
         '''
         preLog = []
         postLog = []  
-        for variable in varInfo:
+        for variable in self.nodeVarInfo:
             variable["global"] = variable["name"] in self.globalsInFunc or variable["funcId"] == 0
 
             if variable["global"] and variable["name"] in self.globalDisabledVariables:
                 continue 
 
-            if not variable["global"] and variable["name"] in self.disabledVariables:
+            if not variable["global"] and variable["name"] in self.localDisabledVariables:
                 continue 
 
             if variable["assignValue"] is None:
@@ -65,6 +69,7 @@ class LogInjector(ast.NodeTransformer):
             del variable["syntax"]
             self.varMap[variable["varId"]] = variable
 
+        self.nodeVarInfo= []
         return preLog, postLog
     
     def visit_FunctionDef(self, node):
@@ -76,18 +81,21 @@ class LogInjector(ast.NodeTransformer):
         logStmt = self.generateLtLogStmts(node, "function")
 
         self.funcId = self.logTypeCount
+
+        # Update the log type map to add function specific information
         self.ltMap[self.logTypeCount]["funcid"] = self.logTypeCount
         self.ltMap[self.logTypeCount]["name"] = node.name
 
         # Reset function specific variables before visiting children.
-        self.disabledVariables = []
+        self.localDisabledVariables = []
         self.globalsInFunc = []
 
         self.generic_visit(node)
 
         # Add log statements for arguments. This is temporary and will be replaced.
-        variables = CollectFunctionArgInfo(node, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(variables)
+        self.nodeVarInfo += CollectFunctionArgInfo(node, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
         node.body = [logStmt] + postLog + node.body
         
         self.funcId = 0
@@ -103,15 +111,14 @@ class LogInjector(ast.NodeTransformer):
         '''
         logStmt = self.generateLtLogStmts(node, "child")
 
-        allPreLogs = []
-        allPostLogs = []
         for target in node.targets:
-            varInfo = CollectAssignVarInfo(target, self.logTypeCount, self.funcId).variables
-            preLog, postLog = self.generateVarLogStmts(varInfo)
-            allPreLogs.extend(preLog)
-            allPostLogs.extend(postLog)
+            self.nodeVarInfo += CollectAssignVarInfo(target, self.logTypeCount, self.funcId).variables
+        
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+            
+        preLog, postLog = self.generateVarLogStmts()
 
-        return allPreLogs + [logStmt]+ [node] + allPostLogs
+        return preLog + [logStmt]+ [node] + postLog
     
     def visit_AugAssign(self, node):
         '''
@@ -119,8 +126,9 @@ class LogInjector(ast.NodeTransformer):
         '''
         logStmt = self.generateLtLogStmts(node, "child")
 
-        varInfo = CollectAssignVarInfo(node.target, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(varInfo)
+        self.nodeVarInfo += CollectAssignVarInfo(node.target, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
 
         return preLog + [logStmt]+ [node] + postLog
     
@@ -132,8 +140,9 @@ class LogInjector(ast.NodeTransformer):
         logStmt = self.generateLtLogStmts(node, "child")
 
         if node.value:
-            varInfo = CollectAssignVarInfo(node.target, self.logTypeCount, self.funcId).variables
-            preLog, postLog = self.generateVarLogStmts(varInfo)
+            self.nodeVarInfo += CollectAssignVarInfo(node.target, self.logTypeCount, self.funcId).variables
+            self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+            preLog, postLog = self.generateVarLogStmts()
             return preLog + [logStmt]+ [node] + postLog
         else:
             return [logStmt, node]
@@ -150,8 +159,9 @@ class LogInjector(ast.NodeTransformer):
     def injectLogTypesA(self, node):
         logStmt = self.generateLtLogStmts(node, "child")
         self.generic_visit(node)
-        varInfo = CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(varInfo)
+        self.nodeVarInfo += CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
         return [logStmt] + [node] + postLog
     
     def visit_Global(self, node):
@@ -162,7 +172,7 @@ class LogInjector(ast.NodeTransformer):
         if (self.funcId == 0):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
-            self.disabledVariables += getDisabledVariables(node)
+            self.localDisabledVariables += getDisabledVariables(node)
         return self.injectLogTypesA(node)
 
     def visit_Pass(self, node):
@@ -208,8 +218,9 @@ class LogInjector(ast.NodeTransformer):
     def injectLogTypesB(self, node):
         logStmt = self.generateLtLogStmts(node, "child")
         self.generic_visit(node)
-        varInfo = CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(varInfo)
+        self.nodeVarInfo += CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
         node.body = postLog + node.body
         return [logStmt, node]
 
@@ -235,8 +246,9 @@ class LogInjector(ast.NodeTransformer):
     def injectLogTypesC(self, node):
         logStmt = self.generateLtLogStmts(node, "child")
         self.generic_visit(node)
-        varInfo = CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(varInfo)
+        self.nodeVarInfo += CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
         node.body = [logStmt] + postLog + node.body
         return [node]
 
@@ -268,8 +280,9 @@ class LogInjector(ast.NodeTransformer):
     def injectLogTypesD(self, node):
         logStmt = self.generateLtLogStmts(node, "child")
         self.generic_visit(node)
-        varInfo = CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
-        preLog, postLog = self.generateVarLogStmts(varInfo)
+        self.nodeVarInfo += CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
+        self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
+        preLog, postLog = self.generateVarLogStmts()
         node.body = postLog + node.body + [logStmt]
         return [logStmt, node]
     

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -170,17 +170,10 @@ class LogInjector(ast.NodeTransformer):
 
     def visit_Expr(self, node):
         # Save disabled variables.
-        # Save disabled variables.
         if (self.funcId == 0):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
             self.localDisabledVariables += getDisabledVariables(node)
-
-        # Replace traceid comments with log statements.
-        traceVar = getTraceId(node)
-        if (traceVar):
-            return getTraceIdLogStmt(traceVar["type"], traceVar["variable"])
-
 
         # Replace traceid comments with log statements.
         traceVar = getTraceId(node)

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -174,7 +174,7 @@ class LogInjector(ast.NodeTransformer):
         if (self.funcId == 0):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
-            self.disabledVariables += getDisabledVariables(node)
+            self.localDisabledVariables += getDisabledVariables(node)
 
         # Replace traceid comments with log statements.
         traceVar = getTraceId(node)

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getDisabledVariables
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getDisabledVariables, getTraceId, getTraceIdLogStmt
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -172,7 +172,12 @@ class LogInjector(ast.NodeTransformer):
         if (self.funcId == 0):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
-            self.localDisabledVariables += getDisabledVariables(node)
+            self.disabledVariables += getDisabledVariables(node)
+
+        traceVar = getTraceId(node)
+        if (traceVar):
+            return getTraceIdLogStmt(traceVar["type"], traceVar["variable"])
+
         return self.injectLogTypesA(node)
 
     def visit_Pass(self, node):

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -49,9 +49,12 @@ class ProgramProcessor:
                 source = f.read()
 
             currAst = ast.parse(source)
-            injector = LogInjector(currAst, ltMap, varMap, logTypeCount)
+            injector = LogInjector(currAst, ltMap, logTypeCount)
 
             logTypeCount = injector.logTypeCount
+
+            for key in injector.varMap:
+                varMap[key] = injector.varMap[key]
 
             fileTree[currRelPath] = {
                 "source": source,

--- a/injector/VariableCollectors/BaseVariableCollector.py
+++ b/injector/VariableCollectors/BaseVariableCollector.py
@@ -1,0 +1,29 @@
+import ast
+import uuid
+
+class VariableCollectorBase:
+    '''
+        Base class for collecting var info and generation var info object.
+    '''
+    var_count = 0
+    
+    def __init__(self, logTypeId, funcId):
+        self.variables = []
+        self.logTypeId = logTypeId
+        self.funcId = funcId
+    
+    def getVarInfo(self, name, keys, syntax, node):
+        '''
+            Appends varinfo object to the variables list.
+        '''
+        VariableCollectorBase.var_count += 1
+        self.variables.append({
+            "varId": VariableCollectorBase.var_count,
+            "name": name,
+            "keys": keys,
+            "syntax": syntax,
+            "assignValue": node,
+            "logType": self.logTypeId,
+            "funcId": self.funcId,
+            "isTemp": node is not None
+        })

--- a/injector/VariableCollectors/CollectCallVariables.py
+++ b/injector/VariableCollectors/CollectCallVariables.py
@@ -1,0 +1,115 @@
+import ast
+import uuid
+from injector.VariableCollectors.BaseVariableCollector import VariableCollectorBase
+from injector.helper import getEmptyRootNode
+
+class CollectCallVariables(ast.NodeVisitor, VariableCollectorBase):
+    '''
+        This class visits all Call nodes and extracts the variable names
+        as well as the keys.
+    '''
+
+    def __init__(self, node, logTypeId, funcId, existingVariables):
+        VariableCollectorBase.__init__(self, logTypeId, funcId)
+        self.keys = []
+        self.existingVars = existingVariables
+        self.containsSlice = False
+
+        if 'body' in node._fields:
+            node = getEmptyRootNode(node)
+
+        # Process any child nodes if they are call instances
+        for childNode in ast.walk(node):
+            if isinstance(childNode, ast.Call):
+                self.generic_visit(ast.Module(body=[childNode.func], type_ignores=[]))
+                self.saveVariableInfo(childNode.func)
+
+    def saveVariableInfo(self, childNode):
+        '''
+            Save the variable info if the necessary conditions are met:
+            - At least one key was found (first key is the variable name)
+            - The variable exists in the current stack
+            - If the variable containes a slice, log the entire variable
+
+            a["b"]["c"].append(1)
+            keys = [
+                {type:"variable",value:a},
+                {type:"key",value:"b"},
+                {type:"key",value:"c"},
+                {type:"key",value:"append"}
+            ]
+
+            - Name is first element in the keys list.
+            - The last element is the function call and it needs to be removed.
+            - The syntax will be a["b"]["c"].append, so we need to remove everything 
+              to the right of the final dot.
+        '''
+        if len(self.keys) <= 1:
+            return
+        
+        name = self.keys.pop(0)["value"]
+        self.keys.pop()
+
+        if self.containsSlice:
+            self.getVarInfo(name, [], name, None)
+            return
+
+        if self.isValidVariableName(name):
+            syntax = ast.unparse(childNode)
+            if ("." in syntax):
+                syntax = ''.join(syntax.rpartition('.')[:-2])
+            self.getVarInfo(name, self.keys, syntax, None)
+            return
+
+    def isValidVariableName(self, name):
+        '''
+            Check if the variable name is in the current stack.
+        '''
+        for varKey in self.existingVars:
+            if name == self.existingVars[varKey]["name"]:
+                return True
+        return False
+        
+    def getVariableName(self):
+        '''
+            Generates a remporary variable name using the uuid module. This
+            variable will be hidden from the user in the diagnostic log viewer.
+        '''
+        return "asp_temp_var_" + str(uuid.uuid1()).replace("-", "")
+
+    def visit_Subscript(self, node):
+        '''
+            If any of the subscript nodes are an expression that need 
+            to be evaluated, then create a temporary variable and replace
+            the subscript with the name of the temporary variable. 
+        '''
+        if isinstance(node.slice, (ast.Slice, ast.Tuple)):
+            self.generic_visit(node)
+            self.containsSlice = True
+
+        elif not isinstance(node.slice, (ast.Constant, ast.Name)):
+            self.generic_visit(ast.Module(body=[node.value], type_ignores=[]))
+
+            varName = self.getVariableName()
+            self.keys.append({"type": "temp_variable", "value": varName})
+            self.getVarInfo(varName, [], varName, node.slice)
+
+            node.slice = ast.Name(id= varName, ctx=ast.Load())
+        else:
+            self.generic_visit(node)
+        return node
+    
+    def visit_Name(self, node):
+        self.generic_visit(node)
+        self.keys.append({"type":"variable", "value":node.id})
+        return node
+    
+    def visit_Attribute(self, node):
+        self.generic_visit(node)
+        self.keys.append({"type":"key", "value":node.attr})
+        return node
+    
+    def visit_Constant(self, node):
+        self.generic_visit(node)
+        self.keys.append({"type":"key", "value":node.value})
+        return node

--- a/injector/VariableCollectors/CollectFunctionArgInfo.py
+++ b/injector/VariableCollectors/CollectFunctionArgInfo.py
@@ -1,0 +1,17 @@
+import ast
+from injector.VariableCollectors.BaseVariableCollector import VariableCollectorBase
+
+class CollectFunctionArgInfo(ast.NodeVisitor, VariableCollectorBase):
+    '''
+        Collects the variable info for arguments to the function. 
+        TODO: Remove this class once the feature to extract the
+        arguments from call location are implemented.
+    '''
+
+    def __init__(self, node, logTypeId, funcId):
+        VariableCollectorBase.__init__(self, logTypeId, funcId)
+        self.generic_visit(node)
+    
+    def visit_arg(self, node):
+        self.getVarInfo(node.arg, [], node.arg, None)
+        self.generic_visit(node)

--- a/injector/VariableCollectors/CollectVariableDefault.py
+++ b/injector/VariableCollectors/CollectVariableDefault.py
@@ -1,0 +1,26 @@
+import ast
+from injector.VariableCollectors.BaseVariableCollector import VariableCollectorBase
+from injector.helper import getEmptyRootNode
+
+class CollectVariableDefault(ast.NodeVisitor, VariableCollectorBase):
+    '''
+        This class collects any name nodes in the provided node. For
+        nodes with a body, it removes the children before finding 
+        the valid names. For example, in the case of a for loop,
+        this would log the variable info for the current element in
+        the loop.
+    '''
+
+    def __init__(self, node, logTypeId, funcId):
+        VariableCollectorBase.__init__(self, logTypeId, funcId)
+
+        if 'body' in node._fields:
+            emptyNode = getEmptyRootNode(node)
+            self.generic_visit(emptyNode)
+        else:
+            self.generic_visit(node)
+    
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Store):
+            self.getVarInfo(node.id, [], node.id, None)
+        self.generic_visit(node)

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -218,11 +218,6 @@ def getTraceId(node):
         This function parses the asp-adli-trace-id to extract
         the variable which should be logged to indicate the 
         start and end of a unique trace.
-
-        It parses triple quote comments. 
-        Example:
-        '''adli-trace-id-start <variable_name>'''
-        '''adli-trace-id-end <variable_name>'''
     """
     traceVariable = None
     if "value" in node._fields and isinstance(node.value, ast.Constant):

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -88,6 +88,21 @@ def getAssignStmt(name, value):
         value=value
     ))
 
+def getTraceIdLogStmt(traceType, variable):
+    '''
+        Returns a log statement for trace ids.
+    '''
+    return ast.Expr(
+        value=ast.Call(
+            func=ast.Name(id='aspTraceLog', ctx=ast.Load()),
+            args=[
+                ast.Constant(value=traceType),
+                ast.Name(id=variable, ctx=ast.Load()),
+            ],
+            keywords=[]
+        )
+    )
+
 def getEmptyRootNode(astNode):
     '''
         Removes all child nodes from astnode. This is used to 
@@ -123,6 +138,25 @@ def getLoggingFunction():
     '''
     ).body
 
+def getTraceLoggingFunction():
+    ''' 
+       Returns a funtion used to log trace start and end locations
+
+       Ex:
+       logger.info("@ start <var_value>")
+       runJob(jobInfo)
+       logger.info("@ end <var_value>")
+    '''
+    return ast.parse(
+    '''def aspTraceLog(traceType, value):
+        try:
+            value = json.dumps(value, default=lambda o: o.__dict__ )
+        except:
+            pass
+        logger.info(f"@ {traceType} {value}")
+    '''
+    ).body
+
 def injectRootLoggingSetup(tree, header, fileName):
     '''
         Injects try except structure around the given tree.
@@ -145,10 +179,11 @@ def injectRootLoggingSetup(tree, header, fileName):
     )
     rootLoggingSetup = getRootLoggingSetup(fileName)
     loggingFunction = getLoggingFunction()
+    traceLoggingFunction = getTraceLoggingFunction()
     header = getLoggingStatement(json.dumps(header))
 
     mod = ast.Module(body=[], type_ignores=[])
-    mod.body = rootLoggingSetup + loggingFunction + [header] + [mainTry]
+    mod.body = rootLoggingSetup + loggingFunction + traceLoggingFunction + [header] + [mainTry]
     return mod
 
 def injectLoggingSetup(tree):
@@ -157,8 +192,9 @@ def injectLoggingSetup(tree):
     '''
     loggingSetup = getLoggingSetup()
     loggingFunction = getLoggingFunction()
+    traceLoggingFunction = getTraceLoggingFunction()
     mod = ast.Module(body=[], type_ignores=[])
-    mod.body = loggingSetup + loggingFunction + tree.body
+    mod.body = loggingSetup + loggingFunction + traceLoggingFunction + tree.body
     return mod
 
 def getDisabledVariables(node):
@@ -199,10 +235,16 @@ def getTraceId(node):
         
         variables = re.findall("adli-trace-id-start (.*)", value)
         if len(variables) > 0:
-            return ["start", variables[0]]
+            return {
+                "type": "start",
+                "variable": variables[0]
+            }
         
         variables = re.findall("adli-trace-id-end (.*)", value)
         if len(variables) > 0:
-            return ["end", variables[0]]
+            return {
+                "type": "end",
+                "variable": variables[0]
+            }
         
     return traceVariable

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -66,7 +66,7 @@ def getLtLogStmt(logTypeId):
 
 def getVarLogStmt(name, varId):
     '''
-        Returns exception handler object for given logtypeid.
+        Returns a function call to log the given variables.
     '''
     return ast.Expr(
         value=ast.Call(
@@ -90,7 +90,7 @@ def getAssignStmt(name, value):
 
 def getTraceIdLogStmt(traceType, variable):
     '''
-        Returns a log statement for trace ids.
+       Returns a log statement for trace ids.
     '''
     return ast.Expr(
         value=ast.Call(
@@ -141,11 +141,6 @@ def getLoggingFunction():
 def getTraceLoggingFunction():
     ''' 
        Returns a funtion used to log trace start and end locations
-
-       Ex:
-       logger.info("@ start <var_value>")
-       runJob(jobInfo)
-       logger.info("@ end <var_value>")
     '''
     return ast.parse(
     '''def aspTraceLog(traceType, value):

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -230,10 +230,16 @@ def getTraceId(node):
         
         variables = re.findall("adli-trace-id-start (.*)", value)
         if len(variables) > 0:
-            return ["start", variables[0]]
+            return {
+                "type": "start",
+                "variable": variables[0]
+            }
         
         variables = re.findall("adli-trace-id-end (.*)", value)
         if len(variables) > 0:
-            return ["end", variables[0]]
+            return {
+                "type": "end",
+                "variable": variables[0]
+            }
         
     return traceVariable

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -181,3 +181,28 @@ def getDisabledVariables(node):
             disabledVariables = variables[0].split()
         
     return disabledVariables
+
+def getTraceId(node):
+    """
+        This function parses the asp-adli-trace-id to extract
+        the variable which should be logged to indicate the 
+        start and end of a unique trace.
+
+        It parses triple quote comments. 
+        Example:
+        '''adli-trace-id-start <variable_name>'''
+        '''adli-trace-id-end <variable_name>'''
+    """
+    traceVariable = None
+    if "value" in node._fields and isinstance(node.value, ast.Constant):
+        value = node.value.value
+        
+        variables = re.findall("adli-trace-id-start (.*)", value)
+        if len(variables) > 0:
+            return ["start", variables[0]]
+        
+        variables = re.findall("adli-trace-id-end (.*)", value)
+        if len(variables) > 0:
+            return ["end", variables[0]]
+        
+    return traceVariable

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -230,16 +230,10 @@ def getTraceId(node):
         
         variables = re.findall("adli-trace-id-start (.*)", value)
         if len(variables) > 0:
-            return {
-                "type": "start",
-                "variable": variables[0]
-            }
+            return ["start", variables[0]]
         
         variables = re.findall("adli-trace-id-end (.*)", value)
         if len(variables) > 0:
-            return {
-                "type": "end",
-                "variable": variables[0]
-            }
+            return ["end", variables[0]]
         
     return traceVariable

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -70,7 +70,7 @@ def getVarLogStmt(name, varId):
     '''
     return ast.Expr(
         value=ast.Call(
-            func=ast.Name(id='aspAdliLog', ctx=ast.Load()),
+            func=ast.Name(id='aspAdliVarLog', ctx=ast.Load()),
             args=[
                 ast.Name(id=name, ctx=ast.Load()),
                 ast.Constant(value=varId)
@@ -103,18 +103,18 @@ def getEmptyRootNode(astNode):
 def getLoggingFunction():
     ''' 
        Returns a funtion used to log values based on their type as an AST node
-       containing the aspAdliLog function definition.
+       containing the aspAdliVarLog function definition.
        
-       The aspAdliLog function logs values with special handling for objects:
+       The aspAdliVarLog function logs values with special handling for objects:
        - For objects with __dict__, it logs their dictionary representation
        - For other values, it logs their string representation
        
        Returns:
-          ast.Module: AST node containing the aspAdliLog function definition
+          ast.Module: AST node containing the aspAdliVarLog function definition
     '''
 
     return ast.parse(
-    '''def aspAdliLog(val, varid):
+    '''def aspAdliVarLog(val, varid):
         try:
             val = json.dumps(val, default=lambda o: o.__dict__ )
         except:


### PR DESCRIPTION
This PR adds a feature to log the start and end of unique traces at the given locations with the provided variable value as the unique id. This involves parsing the trace-id comment, extracting the variable name and replacing it with the appropriate log statement. For example:
```
def jobHandler (jobInfo):
    '''adli-trace-id-start jobInfo['uid']'''
    runJob(jobInfo)
    '''adli-trace-id-end jobInfo['uid']'''

# becomes

def jobHandler (jobInfo):
    logger.info(f"@ start {jobInfo["uid"]})
    runJob(jobInfo)
    logger.info(f"@ end {jobInfo["uid"]})
```
This will allow asp-query-handler to extract the unique traces from each program in the system and link them together using the unique id. Ultimately, this will allow ASP to automatically trace the request as it moves through the system and extract system level traces that can be used to perform system level automated root cause analysis.

There are definitely ways to automatically extract the traces by scanning variable values and identifying function calls with unique data. However, at this stage, since we are the ones building the system, the added complexity of automating this isn't necessary at this point. Instead, I will allow the user to delineate the start and end of a unique trace across the system using unique ids. 

Note: A future PR is planned to unify all the injected logging functions and comment parsing in the ADLI tool 

## Validation Performed
The PR was validated using the following files:
1. adli.clp.zst: A unique trace id was added to the program for each file that was processed. The program was executed and the log file that was generated was opened in the diagnostic log viewer to verify that the trace start and end position was captured.

2. compress.clp.zst: This file was generated by injecting logs into [this ](https://github.com/vancanhuit/simple-data-compression)interesting repo. A unique trace id was added to the program before the data was compressed. The program was executed and the log file that was generated was opened in the diagnostic log viewer to verify that the trace start and end position was captured.

[validation_files.zip](https://github.com/user-attachments/files/19330552/validation_files.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced logging capabilities that now automatically capture and log trace identifiers from specially marked code sections.
  - Improved detection of trace start and end signals to provide clearer insights during application execution.
  - Added new functions to generate logging statements for trace IDs and handle trace logging within expressions.
  - New classes introduced for collecting variable information from function calls and arguments.
  
- **Bug Fixes**
  - Updated existing functions to clarify their behavior and improve logging accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->