### PR TITLE
Assign statements for keys that are expressions in call nodes are inserted into tree (fixes #41). (#42)

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -100,7 +100,7 @@ class LogInjector(ast.NodeTransformer):
         
         self.funcId = 0
         
-        return node
+        return preLog + [node]
     
     def visit_AsyncFunctionDef(self, node):
         return self.visit_FunctionDef(node)
@@ -162,7 +162,7 @@ class LogInjector(ast.NodeTransformer):
         self.nodeVarInfo += CollectVariableDefault(node, self.logTypeCount, self.funcId).variables
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
-        return [logStmt] + [node] + postLog
+        return preLog + [logStmt] + [node] + postLog
     
     def visit_Global(self, node):
         self.globalsInFunc += node.names
@@ -229,7 +229,7 @@ class LogInjector(ast.NodeTransformer):
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
         node.body = postLog + node.body
-        return [logStmt, node]
+        return preLog + [logStmt, node]
 
     def visit_With(self, node):
         return self.injectLogTypesB(node)
@@ -257,7 +257,7 @@ class LogInjector(ast.NodeTransformer):
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
         node.body = [logStmt] + postLog + node.body
-        return [node]
+        return preLog + [node]
 
     def visit_ClassDef(self, node):
         return self.injectLogTypesC(node)
@@ -291,7 +291,7 @@ class LogInjector(ast.NodeTransformer):
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
         node.body = postLog + node.body + [logStmt]
-        return [logStmt, node]
+        return preLog + [logStmt, node]
     
     def visit_For(self, node):
         return self.injectLogTypesD(node)


### PR DESCRIPTION
For variables with keys that contain expressions, an assign statement is generated to store the output of the expression in a temporary variable. This temporary variable is accessed as the key in place of the expression that needs to be evaluated. 

In PR #39, a feature was introduced to extract variables and keys from function calls made by variables. However, the code was not updated to insert the assign statements.

This PR updates the code to insert the assign statements to make the temporary variables accessible in place of the expression that was evaluated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logging functionality to consistently include additional pre-log context in outputs, ensuring a more coherent and informative log sequence for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->