### PR TITLE
Add feature to tag functions that are the start of a unique trace.

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getDisabledVariables, getTraceId, getTraceIdLogStmt
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getDisabledVariables
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -178,11 +178,6 @@ class LogInjector(ast.NodeTransformer):
             self.globalDisabledVariables += getDisabledVariables(node)
         else:
             self.localDisabledVariables += getDisabledVariables(node)
-
-        # Replace traceid comments with log statements.
-        traceVar = getTraceId(node)
-        if (traceVar):
-            return getTraceIdLogStmt(traceVar["type"], traceVar["variable"])
 
         return self.injectLogTypesA(node)
 

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -66,6 +66,11 @@ class LogInjector(ast.NodeTransformer):
                 preLog.append(getAssignStmt(variable["name"], variable["assignValue"]))
                 preLog.append(getVarLogStmt(variable["syntax"], variable["varId"]))
 
+            ''' 
+            Variables named "asp_uid" mark a function as the start of a unique trace.
+            It is a reserved adli keyword and coming updates will ensure that it is only
+            written to once in a function and will raise an error if this is violated.
+            '''
             if variable["name"] == "asp_uid":
                 self.ltMap[variable["funcId"]]["isUnique"] = True
 

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -37,6 +37,7 @@ class LogInjector(ast.NodeTransformer):
             "lineno": node.lineno,
             "end_lineno": node.end_lineno,
             "type": type,
+            "isUnique": False
         }
 
         return getLtLogStmt(self.logTypeCount)
@@ -64,6 +65,9 @@ class LogInjector(ast.NodeTransformer):
             else:                
                 preLog.append(getAssignStmt(variable["name"], variable["assignValue"]))
                 preLog.append(getVarLogStmt(variable["syntax"], variable["varId"]))
+
+            if variable["name"] == "asp_uid":
+                self.ltMap[variable["funcId"]]["isUnique"] = True
 
             del variable["assignValue"]
             del variable["syntax"]


### PR DESCRIPTION
In PR #38, functionality was added to mark the start and end of a unique trace by logging the boundaries. However, I decided that this was a subpar approach and that the better way to do this would be to mark unique function calls. With diagnostic logging, the diagnostic data is the program execution itself and traces can be extracted using the call stack.

With this approach, by defining a variable named "asp_uid" in a function, it marks that function as the start of a unique trace. When processing the CDL file in the system processor, the trace is started when the unique function is added to the stack and it ends when it is removed. This approach would allow us to automatically extract unique traces and it would also support nested unique traces. 

Example:
```
def jobHandler(job):
    asp_uid = job["uid"]

# example logtype map becomes:
 
#  "44": {
#        "id": 44,
#        "funcid": 44,
#        "lineno": 28,
#        "end_lineno": 85,
#        "type": "function",
#        "isUnique": true,
#        "name": "jobHandler"
#    },
```

This concept can be extended to any variable but the variable asp_uid is guaranteed to be unique. Future PR's will introduce checks to verify that asp_uid is only assigned once per function and that it isn't defined in the global scope.

In the automated system viewer, when a function that is the start of a unique trace is inspected, the queries can be filtered using the functions variable values, or all unique executions can be inspected.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced log tracking with a new uniqueness flag to differentiate log entries.
  - Improved state management of logs by automatically flagging those with a specific identifier, supporting more accurate log analysis.
  
- **Bug Fixes**
  - Removed unused trace logging functions, streamlining the logging setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->