### PR TITLE
Add feature to uniquely identify every variable instance.

### DIFF
--- a/injector/VariableInjectors/ValueKeyInjector.py
+++ b/injector/VariableInjectors/ValueKeyInjector.py
@@ -1,0 +1,33 @@
+import ast
+
+from injector.helper import getEmptyRootNode
+from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
+
+class ValueKeyInjector(ast.NodeTransformer):
+
+    def __init__(self, node, varMap, funcId):
+        self.varMap = varMap
+        self.funcId = funcId
+
+        if 'body' in node._fields:
+            node = getEmptyRootNode(node)
+    
+        self.generic_visit(node)
+
+    def getVariable(self, name):
+        for id in self.varMap:
+            v = self.varMap[id]
+            if v["name"] == name and (self.funcId == v["funcId"] or v["global"]):
+                return v
+            
+        return None
+    
+    def insertValueKey(self, node):
+        return ast.Subscript(value=node, slice= ast.Constant(value="asp_value"))
+
+    def visit_Name(self,node):
+        varInfo = self.getVariable(node.id)
+        if varInfo and isinstance(node.ctx, ast.Load):
+            node = self.insertValueKey(node)
+
+        return node

--- a/injector/injectedFunctions.py
+++ b/injector/injectedFunctions.py
@@ -1,0 +1,33 @@
+import logging
+import json
+import uuid
+
+logger = logging.getLogger(__name__)
+
+def varLog(val, varid):
+    ''' 
+       Returns a funtion used to log values based on their type as an AST node
+       containing the aspAdliVarLog function definition.
+       
+       The aspAdliVarLog function logs values with special handling for objects:
+       - For objects with __dict__, it logs their dictionary representation
+       - For other values, it logs their string representation
+       
+       Returns:
+          ast.Module: AST node containing the aspAdliVarLog function definition
+    '''
+    isDict = isinstance(val, dict)
+
+    if (isDict):
+        if "asp_uid" not in val:
+            val = {"asp_uid": str(uuid.uuid4()), "asp_value": val}
+    else:
+        val = {"asp_uid": str(uuid.uuid4()), "asp_value": val}
+    
+    try:
+        jsonVal = json.dumps(val, default=lambda o: o.__dict__ )
+        logger.info(f"# {varid} {jsonVal}")
+    except:
+        logger.info(f"# {varid} {val}")
+
+    return val


### PR DESCRIPTION
Note: In the current state of this PR, assigning a UID to each variable instance is working. However, the logic for replacing variables with their "asp_value" key is being developed. When it is ready, I will remove this message and mark the PR as ready.

----

This PR adds functionality to assign a unique id to every variable instance. 

For example:
```
varA = 123
varA = aspAdliVarLog(varA, <varid>)

# the value of varA becomes

#    {
#        "asp_uid": str(uuid.uuid4()),
#        "asp_value": 123
#    }
```

## Optimize Logging
This will allow us to recall the value of variables using the UID instead of logging it again. For example, we can get the value of function arguments by only logging the uid and we can uniquely identify every instance of self. 

## Automated Root Cause Analysis
This will also allow us to perform automated root case analysis. When we encounter an exception, depending on the type of error, we have to trace the value of the variable backwards. This will allow us to identify the point in the execution when the program would inevitably fail. As we trace the variable back, we will build a variable tree which can be used to look at the root cause at different levels. In cases where a variable is dependent on multiple variables as it is traced back, the variable tree would branch out further.

More details on this implementation will be provided in the diagnostic log viewer repo when the PR for implementing automated root cause analysis is opened. 

## Implementation

To assign a unique id to each variable, the tool does the following:

### Assign unique id to variable
- Before a variable logging statement is generated, if the value does not have the `asp_uid` key in it, then create an object with the  following keys. 
    - The first key is `asp_uid` and its value is a random uid generated using the UUID module. 
    - The second key is `asp_value` key and its value is the value of the variable. This object is returned by the variable logging function and it is used to replace the variable value.
- This approach will ensure that every logged variable has a unique id.

### Replace variable names with its `asp_value` key value
- For every variable that was extracted by the ADLI tool, if it is loaded again, replace its name with the value of its `asp_value` key. 
- Since we are only replacing variables that were extracted by the ADLI tool, it is guaranteed to have an `asp_uid` key because we assign it a value when the extracted variable is logged.

### Passing variable by uid reference
- For function calls made by extracted variables, replace the variable name with the value of the "asp_value" key. However, if any of the function call arguments are extracted variable names, then pass the "asp_uid" key value. This will allow the user to load the value of the variable by using the UID. 
- For function calls that are not contained in the program, we will have to pass in the variable value directly. I will share more details on this in a coming update.