### PR TITLE
Improve approach to identifying and assembling system level traces.

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAssignFuncUidStmt
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -103,13 +103,16 @@ class LogInjector(ast.NodeTransformer):
         self.localDisabledVariables = []
         self.globalsInFunc = []
 
+        # Log uid in function
+        funcUidLogStmt = getAssignFuncUidStmt()
+
         self.generic_visit(node)
 
         # Add log statements for arguments. This is temporary and will be replaced.
         self.nodeVarInfo += CollectFunctionArgInfo(node, self.logTypeCount, self.funcId).variables
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
-        node.body = [logStmt] + postLog + node.body
+        node.body = [logStmt] + postLog + [funcUidLogStmt] + node.body
         
         self.funcId = 0
         

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAssignFuncUidStmt
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -103,16 +103,13 @@ class LogInjector(ast.NodeTransformer):
         self.localDisabledVariables = []
         self.globalsInFunc = []
 
-        # Log uid in function
-        funcUidLogStmt = getAssignFuncUidStmt()
-
         self.generic_visit(node)
 
         # Add log statements for arguments. This is temporary and will be replaced.
         self.nodeVarInfo += CollectFunctionArgInfo(node, self.logTypeCount, self.funcId).variables
         self.nodeVarInfo += CollectCallVariables(node, self.logTypeCount, self.funcId, self.varMap).variables
         preLog, postLog = self.generateVarLogStmts()
-        node.body = [logStmt] + postLog + [funcUidLogStmt] + node.body
+        node.body = [logStmt] + postLog + node.body
         
         self.funcId = 0
         

--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -69,15 +69,7 @@ class LogInjector(ast.NodeTransformer):
             else:                
                 preLog.append(getAssignStmt(variable["name"], variable["assignValue"]))
                 preLog.append(getVarLogStmt(variable["syntax"], variable["varId"]))
-
-            ''' 
-            Variables named "asp_uid" mark a function as the start of a unique trace.
-            It is a reserved adli keyword and coming updates will ensure that it is only
-            written to once in a function and will raise an error if this is violated.
-            '''
-            if variable["name"] == "asp_uid":
-                self.ltMap[variable["funcId"]]["isUnique"] = True
-
+                
             del variable["assignValue"]
             del variable["syntax"]
             self.varMap[variable["varId"]] = variable

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -13,7 +13,6 @@ def getRootLoggingSetup(logFileName):
     nodes.append(ast.parse("import traceback").body[0])
     nodes.append(ast.parse("import logging").body[0])
     nodes.append(ast.parse("import json").body[0])
-    nodes.append(ast.parse("import uuid").body[0])
     nodes.append(ast.parse("import sys").body[0])
     nodes.append(ast.parse("from pathlib import Path").body[0])
     nodes.append(ast.parse("from clp_logging.handlers import CLPFileHandler").body[0])
@@ -31,7 +30,6 @@ def getLoggingSetup():
     nodes = []
     nodes.append(ast.parse("import logging").body[0])
     nodes.append(ast.parse("import json").body[0])
-    nodes.append(ast.parse("import uuid").body[0])
     nodes.append(ast.parse("logger = logging.getLogger('adli')").body[0])
     return nodes
 
@@ -63,13 +61,6 @@ def getLtLogStmt(logTypeId):
             keywords=[]
         )
     )
-
-def getAssignFuncUidStmt():
-    '''
-        Generates an assign statement to generate a function uid.
-    '''
-    assignStmt = "asp_func_uid = str(uuid.uuid4())"
-    return ast.parse(assignStmt).body[0]
 
 def getVarLogStmt(name, varId):
     '''

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -13,6 +13,7 @@ def getRootLoggingSetup(logFileName):
     nodes.append(ast.parse("import traceback").body[0])
     nodes.append(ast.parse("import logging").body[0])
     nodes.append(ast.parse("import json").body[0])
+    nodes.append(ast.parse("import uuid").body[0])
     nodes.append(ast.parse("import sys").body[0])
     nodes.append(ast.parse("from pathlib import Path").body[0])
     nodes.append(ast.parse("from clp_logging.handlers import CLPFileHandler").body[0])
@@ -30,6 +31,7 @@ def getLoggingSetup():
     nodes = []
     nodes.append(ast.parse("import logging").body[0])
     nodes.append(ast.parse("import json").body[0])
+    nodes.append(ast.parse("import uuid").body[0])
     nodes.append(ast.parse("logger = logging.getLogger('adli')").body[0])
     return nodes
 
@@ -61,6 +63,13 @@ def getLtLogStmt(logTypeId):
             keywords=[]
         )
     )
+
+def getAssignFuncUidStmt():
+    '''
+        Generates an assign statement to generate a function uid.
+    '''
+    assignStmt = "asp_func_uid = str(uuid.uuid4())"
+    return ast.parse(assignStmt).body[0]
 
 def getVarLogStmt(name, varId):
     '''


### PR DESCRIPTION
This PR develops a new approach for assembling system level traces. 

## Background

When assembling system level traces, the objective is to trace the execution flow of the system as data moves from one program to another. I tried a few approaches to solve this problem and they are listed below:

1. In PR #38, I attempted to solve this problem by manually logging the start and end of a unique trace. With this initial approach, my plan was to use the unique id to group traces across programs and link them together. However, I realized that with diagnostic logging, we don't need to manually define traces, instead, we can use function calls to extract unique traces using the call stack. 

2. Using what I learnt from my first approach, in PR #44, I decided to define a variable named asp_uid in functions that are the start of a unique trace. Using this approach, I was able to identify all the traces in the system which were processing the same uid. While I could identify all the traces associated with this unique ID, I was unable to reliably sort the order in which the traces in the system were executed. I tried to use timestamps to sort the traces but this was not reliable. I considered increasing the precision of the timestamps but ultimately this seemed very naïve. 

So I decided to take a step back and think about how I am approaching this problem. What does it mean to assemble a system level trace? This means that we can trace function calls as the data moves from one program to another and the order in which those function calls were executed. 

So I concluded that the best way to approach this was to assign a unique id to every function call during run time. When data is sent from one program to another, this unique runtime function id can be included and when the data is accessed in another program, it knows exactly where the data came from. This will allow us to automatically assemble system level traces by tracing the unique ids. 

## Implementation

My initial approach was to inject a variable named asp_func_uid into every function and assign it a unique value. The idea was that the user would use this value in the data they exchanged between programs. However, I don't like this approach because the variable would only be available in the injected source and it would introduce unnecessary complexity when running programs with and without the injected logs.

I concluded that I will allow the user to define the unique function id in functions that send data between programs. When parsing the CDL file, this unique function id will be assigned to the position in the programs execution.

An example of the usage is:

```
def sendMessage():
    asp_func_uid = str(uuid.uuid4())

    msg = {
        "asp_func_uid": asp_func_uid,
        "value": <value>
    }
    websocket.send(msg)
```

While this may seem similar to my previous approach of creating an asp_uid variable, the functions unique id does not correspond to a variable, instead it corresponds to the position in the execution sequence where the data was moved between programs in the system. 

This will allow us create a trace of unique function calls which can be used to automatically assemble system level traces. When parsing the CDL file, if any of the variable values contain a variable with a key named "asp_func_uid", this tells ASP that this function is part of a continuous system level trace. 

> Note: This means that asp_func_uid is a reserved key that the adli tool excepts the user not to use.

In cases where a function splits a job between two distributed workers, the parallel execution can be traced back to the execution position. 

The changes introduced in this PR are minor, it removes the outdated approach tagging functions as the start of unique traces. The actual implementation of this technique will happen in the sample system and the SystemProcessor in asp will have to be updated to assemble traces using this new information. 

> [!NOTE]  
> This process can be automated further and I will explore that more in the coming PR's.

## Validation Performed

Ran the ADLI tool on adli.py and generated the following CDL file. Opened in DLV and verified that the log file was correctly parsed.
[adli.clp.zip](https://github.com/user-attachments/files/19689509/adli.clp.zip)

Ran the adli_system.py on the sample-system repo and injected logs into the system here:
[output.zip](https://github.com/user-attachments/files/19689489/output.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal logging process by removing legacy special-case handling.
  - Refined variable processing for a more consistent log injection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->