### PR TITLE
Specify system uid using arguments and generate ADLI execution and program execution ids. 

### DIFF
--- a/adli.py
+++ b/adli.py
@@ -65,7 +65,7 @@ def main(argv):
         try:
             with open(sys_info_path) as f:
                 sysinfo = json.load(f)
-                sysinfo["adliSystemId"] = sysuid
+                sysinfo["adliSystemExecutionId"] = sysuid
         except FileNotFoundError:
             print(f"System info file not found: {sys_info_path}", file=sys.stderr)
             return -1

--- a/adli.py
+++ b/adli.py
@@ -3,7 +3,6 @@ import ast
 import os
 import json
 import argparse
-import uuid
 from injector.ProgramProcessor import ProgramProcessor
 
 '''
@@ -44,16 +43,16 @@ def main(argv):
     )
 
     args_parser.add_argument(
-        "-uid",
+        "-sysuid",
         type=str,
-        help="A unique id representing this execution of the adli tool",
+        help="A unique id representing the system this program belongs to.",
         required=False
     )
     
     parsed_args = args_parser.parse_args(argv[1:])
     source = parsed_args.source
     sys_info_path = parsed_args.sysinfo
-    uid = parsed_args.uid
+    sysuid = parsed_args.sysuid
 
     try:
         open(source)
@@ -76,14 +75,10 @@ def main(argv):
             print(f"Error reading system info file: {str(e)}", file=sys.stderr)
             return -1
     else:
-        sysinfo = {}
-
-    # If no unique id was provided, generate one
-    if (uid == None):
-        uid = str(uuid.uuid4())
+        sysinfo = None
 
     workingDirectory = os.path.dirname(os.path.abspath(__file__))
-    processor = ProgramProcessor(source, workingDirectory, uid, sysinfo)
+    processor = ProgramProcessor(source, workingDirectory, sysuid, sysinfo)
     processor.run()
 
 if "__main__" == __name__:

--- a/adli.py
+++ b/adli.py
@@ -65,7 +65,7 @@ def main(argv):
         try:
             with open(sys_info_path) as f:
                 sysinfo = json.load(f)
-                sysinfo["adliSystemUid"] = sysuid
+                sysinfo["adliSystemId"] = sysuid
         except FileNotFoundError:
             print(f"System info file not found: {sys_info_path}", file=sys.stderr)
             return -1

--- a/adli.py
+++ b/adli.py
@@ -43,7 +43,7 @@ def main(argv):
     )
 
     args_parser.add_argument(
-        "-sysuid",
+        "-adlisysuid",
         type=str,
         help="A unique id representing the system this program belongs to.",
         required=False
@@ -52,7 +52,7 @@ def main(argv):
     parsed_args = args_parser.parse_args(argv[1:])
     source = parsed_args.source
     sys_info_path = parsed_args.sysinfo
-    sysuid = parsed_args.sysuid
+    sysuid = parsed_args.adlisysuid
 
     try:
         open(source)
@@ -65,6 +65,7 @@ def main(argv):
         try:
             with open(sys_info_path) as f:
                 sysinfo = json.load(f)
+                sysinfo["adliSystemUid"] = sysuid
         except FileNotFoundError:
             print(f"System info file not found: {sys_info_path}", file=sys.stderr)
             return -1
@@ -78,7 +79,7 @@ def main(argv):
         sysinfo = None
 
     workingDirectory = os.path.dirname(os.path.abspath(__file__))
-    processor = ProgramProcessor(source, workingDirectory, sysuid, sysinfo)
+    processor = ProgramProcessor(source, workingDirectory, sysinfo)
     processor.run()
 
 if "__main__" == __name__:

--- a/adli_system.py
+++ b/adli_system.py
@@ -21,7 +21,7 @@ def injectSystemLogs(sdf):
     for program in programs:
         print(f"Processing program: {program}")
         path = Path(TEMP_DIRECTORY) / program
-        result = subprocess.run(['python3', 'adli.py', path, '-sysInfo', sdfPath, '-adliSysUid', uid ])
+        result = subprocess.run(['python3', 'adli.py', path, '-sysinfo', sdfPath, '-adlisysuid', uid ])
 
     print("Finished injecting logs into the system.")
     return 0

--- a/adli_system.py
+++ b/adli_system.py
@@ -21,7 +21,7 @@ def injectSystemLogs(sdf):
     for program in programs:
         print(f"Processing program: {program}")
         path = Path(TEMP_DIRECTORY) / program
-        result = subprocess.run(['python3', 'adli.py', path, '-sysinfo', sdfPath, '-uid', uid ])
+        result = subprocess.run(['python3', 'adli.py', path, '-sysInfo', sdfPath, '-adliSysUid', uid ])
 
     print("Finished injecting logs into the system.")
     return 0

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -6,10 +6,11 @@ import traceback
 import json
 import time
 import os
+import uuid
 
-ADLI_UNIQUE_ID = str(int(time.time()))
+ADLI_EXECUTION_ID = str(uuid.uuid4())
 
-path = Path(os.path.dirname(__file__)) / f"./{ADLI_UNIQUE_ID}.clp.zst"
+path = Path(os.path.dirname(__file__)) / f"{ADLI_EXECUTION_ID}.clp.zst"
 clp_handler = CLPFileHandler(path)
 logger = logging.getLogger("adli")
 logger.setLevel(logging.INFO)
@@ -63,6 +64,12 @@ class AdliLogger:
             Logs the header, 
         '''
         self.count += 1
-        logger.info(header)
+        # header.executionId = ADLI_EXECUTION_ID
+        obj = {
+            "executionId": ADLI_EXECUTION_ID,
+            "timestamp": str(time.time()),
+        }
+        header["execInfo"] = obj
+        logger.info(json.dumps(header))
 
 adli = AdliLogger()

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -64,12 +64,10 @@ class AdliLogger:
             Logs the header, 
         '''
         self.count += 1
-        # header.executionId = ADLI_EXECUTION_ID
-        obj = {
-            "executionId": ADLI_EXECUTION_ID,
+        header["execInfo"] = {
+            "programExecutionId": ADLI_EXECUTION_ID,
             "timestamp": str(time.time()),
         }
-        header["execInfo"] = obj
         logger.info(json.dumps(header))
 
 adli = AdliLogger()

--- a/injector/LoggerInstance/getLoggerInstance.py
+++ b/injector/LoggerInstance/getLoggerInstance.py
@@ -2,24 +2,7 @@ import ast
 import os
 from pathlib import Path
 
-class SetUniqueId(ast.NodeTransformer):
-    '''
-        Given the AdliLogger.py file, this class
-        updates the variable value of ADLI_UNIQUE_ID
-        with the given uniqueid.
-    '''
-
-    def __init__(self, uniqueid):
-        self.uniqueid = uniqueid
-
-    def visit_Assign(self, node):
-        isName = isinstance(node.targets[0], ast.Name)
-        if (isName and (node.targets[0].id == "ADLI_UNIQUE_ID")):
-            node.value = ast.Constant(value=self.uniqueid)
-        return node
-    
-
-def getLoggerInstanceWithUid(uniqueid):
+def getLoggerInstance():
     '''
         Given a uniqueid, this function sets the unique id of
         AdliLogger.py and returns the unparsed source.
@@ -28,7 +11,6 @@ def getLoggerInstanceWithUid(uniqueid):
     with open(path, "r") as f:
         source = f.read()
         tree = ast.parse(source)
-        SetUniqueId(uniqueid).visit(tree)
         return ast.unparse(tree)
 
 

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -1,6 +1,7 @@
 import shutil
 import os
 import ast
+import uuid
 import json
 from pathlib import Path
 from injector import helper
@@ -16,14 +17,15 @@ class ProgramProcessor:
         imports found using the log injector. It then writes the injected
         source files to the output directory.
     '''
-    def __init__(self, sourceFile, workingDirectory, uniqueid, sysinfo):
+    def __init__(self, sourceFile, workingDirectory, sysuid, sysinfo):
         self.sourceFile = os.path.abspath(sourceFile)
         self.fileName = Path(self.sourceFile).stem
         self.sourceFileDirectory = os.path.dirname(self.sourceFile)                
         self.outputDirectory = os.path.join(workingDirectory, "output", self.fileName)
 
         self.sysinfo = sysinfo
-        self.uniqueid = uniqueid
+        self.sysuid = sysuid
+        self.uniqueid = str(uuid.uuid4())
 
         if os.path.exists(self.outputDirectory):
             shutil.rmtree(self.outputDirectory)
@@ -82,6 +84,7 @@ class ProgramProcessor:
             "ltMap": ltMap,
             "varMap": varMap,
             "metadata": metadata,
+            "sysuid": self.sysuid,
             "sysinfo": self.sysinfo,
             "uid": self.uniqueid
         }

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -17,14 +17,13 @@ class ProgramProcessor:
         imports found using the log injector. It then writes the injected
         source files to the output directory.
     '''
-    def __init__(self, sourceFile, workingDirectory, sysuid, sysinfo):
+    def __init__(self, sourceFile, workingDirectory, sysinfo):
         self.sourceFile = os.path.abspath(sourceFile)
         self.fileName = Path(self.sourceFile).stem
         self.sourceFileDirectory = os.path.dirname(self.sourceFile)                
         self.outputDirectory = os.path.join(workingDirectory, "output", self.fileName)
 
         self.sysinfo = sysinfo
-        self.sysuid = sysuid
         self.uniqueid = str(uuid.uuid4())
 
         if os.path.exists(self.outputDirectory):
@@ -84,7 +83,6 @@ class ProgramProcessor:
             "ltMap": ltMap,
             "varMap": varMap,
             "metadata": metadata,
-            "sysuid": self.sysuid,
             "sysinfo": self.sysinfo,
             "uid": self.uniqueid
         }

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from injector import helper
 from injector.FindLocalImports import findLocalImports
 from injector.LogInjector import LogInjector
-from injector.LoggerInstance.getLoggerInstance import getLoggerInstanceWithUid
+from injector.LoggerInstance.getLoggerInstance import getLoggerInstance
 
-SAVE_LT_MAP = True
+SAVE_HEADER = True
 
 class ProgramProcessor:
     '''
@@ -24,7 +24,7 @@ class ProgramProcessor:
         self.outputDirectory = os.path.join(workingDirectory, "output", self.fileName)
 
         self.sysinfo = sysinfo
-        self.uniqueid = str(uuid.uuid4())
+        self.adliExecUid = str(uuid.uuid4())
 
         if os.path.exists(self.outputDirectory):
             shutil.rmtree(self.outputDirectory)
@@ -77,18 +77,18 @@ class ProgramProcessor:
                 "ast": currAst                
             })
 
+        metadata["adliUid"] = self.adliExecUid
         # Create header object
         header = {
             "fileTree": fileTree,
             "ltMap": ltMap,
             "varMap": varMap,
-            "metadata": metadata,
-            "sysinfo": self.sysinfo,
-            "uid": self.uniqueid
+            "programInfo": metadata,
+            "sysinfo": self.sysinfo
         }
 
         # Add AdliLogger.py to output directory
-        source = getLoggerInstanceWithUid(self.uniqueid)
+        source = getLoggerInstance()
         with open(Path(self.outputDirectory) / "AdliLogger.py", "w+") as f:
             f.write(source)
         
@@ -103,6 +103,6 @@ class ProgramProcessor:
             with open(fileInfo["outputFilePath"], 'w+') as f:
                 f.write(ast.unparse(currAst))
 
-        if SAVE_LT_MAP:
+        if SAVE_HEADER:
             with open(os.path.join(self.outputDirectory, "header.json"), "w+") as f:
                 f.write(json.dumps(header))

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -40,7 +40,7 @@ class ProgramProcessor:
         fileOutputInfo = []
         files = findLocalImports(self.sourceFile)
         logTypeCount = 0
-        metadata = {}
+        programMetadata = {}
 
         # Process every file found in the program
         for currFilePath in files:
@@ -58,7 +58,7 @@ class ProgramProcessor:
             injector = LogInjector(currAst, ltMap, logTypeCount)
 
             if(injector.metadata):
-                metadata = injector.metadata
+                programMetadata = injector.metadata
 
             logTypeCount = injector.logTypeCount
 
@@ -77,13 +77,13 @@ class ProgramProcessor:
                 "ast": currAst                
             })
 
-        metadata["adliUid"] = self.adliExecUid
         # Create header object
+        programMetadata["adliId"] = self.adliExecUid
         header = {
             "fileTree": fileTree,
             "ltMap": ltMap,
             "varMap": varMap,
-            "programInfo": metadata,
+            "programInfo": programMetadata,
             "sysinfo": self.sysinfo
         }
 

--- a/injector/ProgramProcessor.py
+++ b/injector/ProgramProcessor.py
@@ -3,6 +3,7 @@ import os
 import ast
 import uuid
 import json
+import time
 from pathlib import Path
 from injector import helper
 from injector.FindLocalImports import findLocalImports
@@ -24,7 +25,11 @@ class ProgramProcessor:
         self.outputDirectory = os.path.join(workingDirectory, "output", self.fileName)
 
         self.sysinfo = sysinfo
-        self.adliExecUid = str(uuid.uuid4())
+        # Create header object
+        self.adliInfo = {
+            "adliExecutionId": str(uuid.uuid4()),
+            "timestamp": str(time.time())
+        }
 
         if os.path.exists(self.outputDirectory):
             shutil.rmtree(self.outputDirectory)
@@ -77,14 +82,14 @@ class ProgramProcessor:
                 "ast": currAst                
             })
 
-        # Create header object
-        programMetadata["adliId"] = self.adliExecUid
+        
         header = {
             "fileTree": fileTree,
             "ltMap": ltMap,
             "varMap": varMap,
             "programInfo": programMetadata,
-            "sysinfo": self.sysinfo
+            "sysInfo": self.sysinfo,
+            "adliInfo": self.adliInfo
         }
 
         # Add AdliLogger.py to output directory

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -110,7 +110,7 @@ def injectRootLoggingSetup(tree, header, fileName):
         finalbody=[]
     )
     loggerInstance = getAdliLoggerInstance()
-    header = getHeaderLogStmt(json.dumps(header))
+    header = getHeaderLogStmt(header)
 
     mod = ast.Module(body=[], type_ignores=[])
     mod.body = [loggerInstance] + [header] + [mainTry]


### PR DESCRIPTION
This PR extends the metadata saved to the header of the CDL file. It introduces new UID's and it restructures how the header is setup.

There are currently four types of metadata:

## System
When the adli tool injects logs into all programs in a system, it passes the system information to the program. This system information includes system uid, description, version, language and adli system tool execution uid.

This information is saved in the header of the CDL file in a key named `sysInfo`.

```
{
    "metadata": {
        "name": "Distributed Sorting System",
        "description": "This system accepts sorting jobs form clients over a webksocket and assigns them to distributed works. It returns the sorted list.",
        "systemVersion": "0.0",
        "systemId": "1234"
    },
    "programs": [
        "simulatedClient/simulatedClient.py",
        "radixSortWorker/radixSortWorker.py",
        "mergeSortWorker/mergeSortWorker.py",
        "bubbleSortWorker/bubbleSortWorker.py",
        "jobHandler/jobHandler.py",
        "utils/start_system.py",
        "utils/stop_system.py"
    ],
    "adliSystemExecutionId": "b968454c-1af7-4884-a341-b544cbebe0bd"
}
```

For example, the system UID can be used to identify all logs belonging to a given system. The ADLI system tool's UID can be used to identify all logs generated by programs injected during a single execution of the ADLI system tool, so far I have been calling this a deployment.

## ADLI 
When the ADLI tool runs, it generates an object that contains an ADLI execution UID and a timestamp for when it was executed. This can be used to reference the log generated by the ADLI tool when it injected logs into this program. 

This information is saved in the header of the CDL file in a key named `adliInfo`.

```
{
    "adliExecutionId": "0cc5949b-3020-4247-bc6b-3a7a1d329ce0",
    "timestamp": "1744587323.0856826"
}
```

## Program
The source code contains metadata about the program. This includes, name, description, language and version.

This information is saved in the header of the CDL file in a key named `programInfo`.

```
{
    "name": "Bubble Sort",
    "description": "A program to receive sorting jobs over a websocket server and return the sorted results.",
    "version": "0.0",
    "language": "python"
}
```

## Execution
When the program is executed, it generates an object that contains a unique id that is used to identify this execution of the program. This is also the name of the log file. It can also include other metadata, such as the OS the program ran on.

This information is saved in the header of the CDL file in a key named `execInfo`.

```
{
    "programExecutionId": "04c2cda2-8782-4e93-8d01-74903c99f967",
    "timestamp": "1744587332.027219"
}
```
## Arguments

- sysinfo : This maps to `sysinfo` in the header. The `adlisysuid` is added as a key to this object.
- adlisysuid: This maps to the adliSystemExecutionId key in `sysinfo`.

The rest is generated within the ADLI tool and during runtime. 

## Validation Performed

The adli_system tool was run on the distributed sorting system using the command:

`python3 adli_system.py https://github.com/vishalpalaniappan/sample-system.git`

The system was run and the following files were generated:
[DistributedSortingSystem.zip](https://github.com/user-attachments/files/19727884/DistributedSortingSystem.zip)

Each log file was inspected to verify that they had the same `systemId`, `adliSystemExecutionId` and unique `adliExecutionId` and `programExecutionId`.

| Program             | System Id | Adli System Execution Id             | Adli Execution Id                    | Program Execution Id                 |
|---------------------|-----------|--------------------------------------|--------------------------------------|--------------------------------------|
| simulatedClient.py  | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | de76b329-636d-44b5-ac52-43e676aeae17 | 00200d3f-5fbd-4072-b3ac-78901454103c |
| radixSortWorker.py  | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | f6e3f0b6-d364-4b5a-82cc-e869c27c78b6 | 7778c777-4ed0-442f-80a5-91dd90550ebd |
| mergeSortWorker.py  | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | e1638156-0a98-46fa-b6c6-31ecbe02375c | f1dec420-b132-41c7-b81a-ab74971d18cf |
| bubbleSortWorker.py | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | 0cc5949b-3020-4247-bc6b-3a7a1d329ce0 | 0cc5949b-3020-4247-bc6b-3a7a1d329ce0 |
| jobHandler.py       | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | 4635de66-7b9d-4309-877c-1aa9064ee7ac | c8220b33-b042-471a-95c7-486f47c7ca2e |
| start_system.py     | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | 1e55769e-afae-4573-808a-d89ff15001a6 | b6b69c98-0672-4d61-9e25-e09effe94313 |
| stop_system.py      | 1234      | 7cc4ebfd-a723-4616-ba4e-02bdeac670d0 | 6efc536a-9bcc-4db6-970b-f68f533bf7f4 | fa169820-2e3c-44b1-a3dd-13b7738be408 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the command-line interface by renaming the identifier option to “-adlisysuid” with a clearer help description.
  - Enhanced logging by incorporating execution context with unique identifiers.

- **Refactor**
  - Streamlined internal processing by generating unique identifiers automatically and adjusting system information defaults.
  - Improved the structure of log entries for better traceability and clarity.
  - Modified how the header is processed for logging, affecting the input format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->