### PR TITLE
Add feature to encode outputs and decode inputs.

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAdliConfiguration
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAdliConfiguration, getEncodedOutputStmt
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -189,6 +189,9 @@ class LogInjector(ast.NodeTransformer):
                 self.localDisabledVariables += parsed["value"]
         elif (parsed and parsed["type"] == "adli_metadata"):
             self.metadata = parsed["value"]
+        elif (parsed and parsed["type"] == "adli_encode_output"):
+            encodedStmt = getEncodedOutputStmt(parsed["value"][0])
+            return encodedStmt
 
         return self.injectLogTypesA(node)
 

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -70,14 +70,15 @@ class AdliLogger:
         }
         logger.info(json.dumps(header))
 
-    def encodeOutput(self, variable):
+    def encodeOutput(self, variableName, value):
         '''
             Encodes the output with the execution id and position.
         '''
+        logger.info(f"* output {variableName}")
         return {
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliPosition": self.count + 1,
-            "adliValue": variable
+            "adliValue": variableName
         }
 
 adli = AdliLogger()

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -78,7 +78,7 @@ class AdliLogger:
         return {
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliPosition": self.count + 1,
-            "adliValue": variableName
+            "adliValue": value
         }
 
 adli = AdliLogger()

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -72,7 +72,12 @@ class AdliLogger:
             "programExecutionId": ADLI_EXECUTION_ID,
             "timestamp": str(time.time()),
         }
-        logger.info(json.dumps(header))
+
+        logInfo = {
+            "type": "adli_header",
+            "header": header
+        }
+        logger.info(json.dumps(logInfo))
 
     def encodeOutput(self, variableName, value):
         '''
@@ -80,7 +85,15 @@ class AdliLogger:
         '''
         self.count += 1
         self.outputCount += 1
-        logger.info(f"* output {ADLI_EXECUTION_ID} {self.count + 1}")
+
+        logInfo = {
+            "type": "adli_output",
+            "execution_id": ADLI_EXECUTION_ID,
+            "execution_index": self.count + 1
+        }
+        
+        logger.info(json.dumps(logInfo))
+
         return {
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliPosition": self.count + 1,
@@ -91,7 +104,15 @@ class AdliLogger:
         if isinstance(value, dict) and "adliExecutionId" in value and "adliPosition" in value:
             self.count += 1
             self.inputCount += 1
-            logger.info(f"* input {value['adliExecutionId']} {value['adliPosition']}")
+
+            logInfo = {
+                "type": "adli_input",
+                "execution_id": ADLI_EXECUTION_ID,
+                "execution_index": self.count + 1
+            }
+
+            logger.info(json.dumps(logInfo))
+
             return value["adliValue"]
         
         return value

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -29,6 +29,8 @@ class AdliLogger:
         self.variableLogCount = 0
         self.stmtLogCount = 0
         self.exceptionLogCount = 0
+        self.inputCount = 0
+        self.outputCount = 0
         pass
 
     def logVariable(self, varid, value):
@@ -38,10 +40,12 @@ class AdliLogger:
         self.count += 1
         self.variableLogCount += 1
         try:
-            value = json.dumps(value, default=lambda o: o.__dict__ )
-            logger.info(f"# {varid} {value}")
+            dumpedValue = json.dumps(value, default=lambda o: o.__dict__ )
+            logger.info(f"# {varid} {dumpedValue}")
         except:
             logger.info(f"# {varid} {value}")
+
+        return self.decodeInput(value)
 
     def logStmt(self, stmtId):
         '''
@@ -74,11 +78,23 @@ class AdliLogger:
         '''
             Encodes the output with the execution id and position.
         '''
-        logger.info(f"* output {variableName}")
+        self.count += 1
+        self.outputCount += 1
+        logger.info(f"* output {ADLI_EXECUTION_ID} {self.count + 1}")
         return {
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliPosition": self.count + 1,
             "adliValue": value
         }
+    
+    def decodeInput(self, value):
+        if isinstance(value, dict) and "adliExecutionId" in value and "adliPosition" in value:
+            self.count += 1
+            self.inputCount += 1
+            logger.info(f"* input {value['adliExecutionId']} {value['adliPosition']}")
+            return value["adliValue"]
+        
+        return value
+
 
 adli = AdliLogger()

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -70,4 +70,14 @@ class AdliLogger:
         }
         logger.info(json.dumps(header))
 
+    def encodeOutput(self, variable):
+        '''
+            Encodes the output with the execution id and position.
+        '''
+        return {
+            "adliExecutionId": ADLI_EXECUTION_ID,
+            "adliPosition": self.count + 1,
+            "adliValue": variable
+        }
+
 adli = AdliLogger()

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -52,20 +52,20 @@ def getVarLogStmt(name, varId):
     '''
         Returns a function call to log the given variables.
     '''
-    return ast.Expr(
-        value=ast.Call(
-            func=ast.Attribute(
-                value=ast.Name(id='adli', ctx=ast.Load()),
-                attr='logVariable',
-                ctx=ast.Load()
-            ),
-            args=[
-                ast.Constant(value=varId),
-                ast.Name(id=name, ctx=ast.Load())
-            ],
-            keywords=[]
-        )
+    logVariableCall = ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id='adli', ctx=ast.Load()),
+            attr='logVariable',
+            ctx=ast.Load()
+        ),
+        args=[
+            ast.Constant(value=varId),
+            ast.Name(id=name, ctx=ast.Load())
+        ],
+        keywords=[]
     )
+
+    return getAssignStmt(name, logVariableCall)
 
 def getAssignStmt(name, value):
     '''
@@ -73,7 +73,7 @@ def getAssignStmt(name, value):
     '''
     return ast.fix_missing_locations(ast.Assign(
         targets=[ast.Name(id=name, ctx=ast.Store)],
-        value=value
+        value= value
     ))
 
 def getEmptyRootNode(astNode):

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -138,6 +138,7 @@ def getEncodedOutputStmt(name):
                 ctx=ast.Load()
             ),
             args=[
+                ast.Constant(value=name),
                 ast.Name(id=name, ctx=ast.Load())
             ],
             keywords=[]

--- a/injector/helper.py
+++ b/injector/helper.py
@@ -125,6 +125,25 @@ def injectLoggingSetup(tree):
     mod.body = [loggerInstance] + tree.body
     return mod
 
+def getEncodedOutputStmt(name):
+    '''
+        Returns an assign statement with the provided arguments.
+    '''
+    return ast.fix_missing_locations(ast.Assign(
+        targets=[ast.Name(id=name, ctx=ast.Store)],
+        value=ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id='adli', ctx=ast.Load()),
+                attr='encodeOutput',
+                ctx=ast.Load()
+            ),
+            args=[
+                ast.Name(id=name, ctx=ast.Load())
+            ],
+            keywords=[]
+        )
+    ))
+
 def getAdliConfiguration(node):
     """
         Checks to see if the node contains valid ADLI configuration info.
@@ -151,7 +170,7 @@ def getAdliConfiguration(node):
         '''
     """
 
-    validCommentTypes = ["adli_disable_variable","adli_metadata"]   
+    validCommentTypes = ["adli_disable_variable","adli_metadata","adli_encode_output"]   
 
     if "value" in node._fields and isinstance(node.value, ast.Constant):     
         comment = node.value.value


### PR DESCRIPTION
This PR encodes any variables that have been specified as outputs with the execution position and execution id before sending it to another program. 

## Specifying Outputs
To specify a variable as an output:
```
'''
{
    "type":"adli_encode_output",
    "value":["message"]
}
''' 
await websocket.send(json.dumps(message))
```

When the ADLI tool processes the program, if it encounters a comment defining the variable as an output, it replaces it with a statement that encodes it as an output. 
```
message = adli.encodeOutput(message)
await websocket.send(json.dumps(message))
```

When the encoded output is read as an input, it will contain the exact position and file where the output came from.  

An example of the log statement which replaces the variable output comment. Note that in the example below, we add one to the log count because the next statement will be the one that triggers the output.
```
{
    "type": "adli_output",
    "adliExecutionId": ADLI_EXECUTION_ID,
    "adliExecutionIndex": self.count + 1
}
```

Note: This approach still isn't fully automated because the user has to specify which variables are the outputs. I will be building this incrementally, while the current approach for identifying outputs isn't fully automated, it will allow us to automatically extract system level traces and develop that workflow.

## Automatically Identifying Inputs
The ADLI tool automatically scans variable values and identifies variables that have been encoded as an output. Using this, it identifies the variable as an input and generates a log statement indicating where this input came from. The JSON log is structured as follows:
```
{
    "type": "adli_input",
    "adliExecutionId": ADLI_EXECUTION_ID,
    "adliExecutionIndex": self.count + 1
}
```

## Validation Performed

Diagnostic logs were injected into the Distributed Sorting System and the job handler was run. A message was sent from postman to the job handler to register a client. 

Message Sent:
```
{
    "code": 1,
    "client": true
}
```

Response Received (program echoes the message):
```
{
    "adliExecutionId": "ec084d23-1421-4acd-8316-d2817c3e1b9d",
    "adliPosition": 158,
    "adliValue": {
        "code": 1,
        "client": true
    }
}
```

The log file was inspected to check the location of the call and it corresponded to the log type id 14 and the statement this corresponds to is:

`await websocket.send(json.dumps(message))`

Injected logs into ADLI tool and performed verification manually:
[adli_log.zip](https://github.com/user-attachments/files/19746897/adli_log.zip)

Collected CDL log from job handler which has inputs and outputs. See console for CDL object.
[input-output.zip](https://github.com/user-attachments/files/19746904/input-output.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging now captures encoded output data with detailed execution context.
	- Updated configuration options enable logging for new encoded output markers.
	- New method added to log encoded output details, including execution ID and position.
	- New function introduced to construct assignment statements for encoded outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->