### PR TITLE
Fix incorrect input log statement and improve docs.

### DIFF
--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -31,11 +31,13 @@ class AdliLogger:
         self.exceptionLogCount = 0
         self.inputCount = 0
         self.outputCount = 0
-        pass
 
     def logVariable(self, varid, value):
         '''
-            Logs the given varid and value.         
+            Logs the given varid and value.     
+
+            :param int varid: A number representing the mapped variable index in varMap.   
+            :param value: Value of the variable being encoded.
         '''
         self.count += 1
         self.variableLogCount += 1
@@ -50,6 +52,8 @@ class AdliLogger:
     def logStmt(self, stmtId):
         '''
             Logs the mapped stmtId.
+
+            :param int stmtId: A number representing the mapped statement index in ltMap.
         '''
         self.count += 1
         self.stmtLogCount += 1
@@ -65,9 +69,13 @@ class AdliLogger:
 
     def logHeader(self, header):
         '''
-            Logs the header, 
+            Log the header of the CDL file.
+
+            :param dict header: Dictionary representing the header of the CDL file.
         '''
         self.count += 1
+
+        # Add execution infomration to header
         header["execInfo"] = {
             "programExecutionId": ADLI_EXECUTION_ID,
             "timestamp": str(time.time()),
@@ -82,14 +90,18 @@ class AdliLogger:
     def encodeOutput(self, variableName, value):
         '''
             Encodes the output with the execution id and position.
+
+            :param str variableName: Name of the variable being encoded.
+            :param value: Value of the variable being encoded.
         '''
         self.count += 1
         self.outputCount += 1
 
         logInfo = {
             "type": "adli_output",
-            "execution_id": ADLI_EXECUTION_ID,
-            "execution_index": self.count + 1
+            "outputName": variableName,
+            "adliExecutionId": ADLI_EXECUTION_ID,
+            "adliExecutionIndex": self.count + 1
         }
         
         logger.info(json.dumps(logInfo))
@@ -101,14 +113,21 @@ class AdliLogger:
         }
     
     def decodeInput(self, value):
+        '''
+            This function is to identify if the variable value is an encoded input.
+            - If it is, log the input metadata and return the raw value of the variable. 
+            - If it isn't, it returns the value.
+
+            :param value: Value of the variable being inspected. 
+        '''
         if isinstance(value, dict) and "adliExecutionId" in value and "adliPosition" in value:
             self.count += 1
             self.inputCount += 1
 
             logInfo = {
                 "type": "adli_input",
-                "execution_id": ADLI_EXECUTION_ID,
-                "execution_index": self.count + 1
+                "adliExecutionId": value["adliExecutionId"],
+                "adliExecutionIndex": value["adliExecutionIndex"]
             }
 
             logger.info(json.dumps(logInfo))

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -108,7 +108,7 @@ class AdliLogger:
 
         return {
             "adliExecutionId": ADLI_EXECUTION_ID,
-            "adliPosition": self.count + 1,
+            "adliExecutionIndex": self.count + 1,
             "adliValue": value
         }
     
@@ -120,7 +120,7 @@ class AdliLogger:
 
             :param value: Value of the variable being inspected. 
         '''
-        if isinstance(value, dict) and "adliExecutionId" in value and "adliPosition" in value:
+        if isinstance(value, dict) and "adliExecutionId" in value and "adliExecutionIndex" in value:
             self.count += 1
             self.inputCount += 1
 

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -34,7 +34,8 @@ class AdliLogger:
 
     def logVariable(self, varid, value):
         '''
-            Logs the given varid and value.     
+            Logs the given varid and value. It also checks to see if the variable
+            value was encoded by the ADLI tool and returns the decoded variable value.
 
             :param int varid: A number representing the mapped variable index in varMap.   
             :param value: Value of the variable being encoded.
@@ -51,7 +52,8 @@ class AdliLogger:
 
     def logStmt(self, stmtId):
         '''
-            Logs the mapped stmtId.
+            Logs the statement id. This corresponds to a statement in the source
+            code. For example: a = 1 is mapped to stmtId 4.
 
             :param int stmtId: A number representing the mapped statement index in ltMap.
         '''
@@ -114,7 +116,7 @@ class AdliLogger:
     
     def decodeInput(self, value):
         '''
-            This function is to identify if the variable value is an encoded input.
+            This function identifies if the variable value is an encoded input.
             - If it is, log the input metadata and return the raw value of the variable. 
             - If it isn't, it returns the value.
 


### PR DESCRIPTION
This PR fixes #63. This issue was introduced in PR #62. See issue for more details.

In addition to fixing this bug, the documentation of AdliLogger functions introduced in PR #62 are improved. 

## Validation Performed

Logs were injected into the simple-data-compression repo to verify that variables, statements and exceptions are correctly logged:
[simple_compress_w_exception.zip](https://github.com/user-attachments/files/19765809/simple_compress_w_exception.zip)

The adli_system.py program was used to inject logs into the Distributed Sorting System and the system was run. The job handler's log was inspected to verify that the correct input and outputs were logged:
[input_output_jobhandler.zip](https://github.com/user-attachments/files/19765819/input_output_jobhandler.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved method documentation with detailed descriptions and parameter explanations.
- **Style**
  - Updated log output key names for consistency and clarity.
  - Removed redundant code for cleaner implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->