### PR TITLE
Add variable value to logged input and output statements; Add statement to log type map.

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -1,5 +1,5 @@
 import ast
-from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAdliConfiguration, getEncodedOutputStmt
+from injector.helper import getVarLogStmt, getLtLogStmt, getAssignStmt, getAdliConfiguration, getEncodedOutputStmt, getEmptyRootNode
 from injector.VariableCollectors.CollectAssignVarInfo import CollectAssignVarInfo
 from injector.VariableCollectors.CollectVariableDefault import CollectVariableDefault
 from injector.VariableCollectors.CollectCallVariables import CollectCallVariables
@@ -38,7 +38,8 @@ class LogInjector(ast.NodeTransformer):
             "lineno": node.lineno,
             "end_lineno": node.end_lineno,
             "type": type,
-            "isUnique": False
+            "isUnique": False,
+            "statement": ast.unparse(getEmptyRootNode(node) if "body" in node._fields else node)
         }
 
         return getLtLogStmt(self.logTypeCount)

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -103,7 +103,8 @@ class AdliLogger:
             "type": "adli_output",
             "outputName": variableName,
             "adliExecutionId": ADLI_EXECUTION_ID,
-            "adliExecutionIndex": self.count + 1
+            "adliExecutionIndex": self.count + 1,
+            "adliValue": value
         }
         
         logger.info(json.dumps(logInfo))
@@ -129,7 +130,8 @@ class AdliLogger:
             logInfo = {
                 "type": "adli_input",
                 "adliExecutionId": value["adliExecutionId"],
-                "adliExecutionIndex": value["adliExecutionIndex"]
+                "adliExecutionIndex": value["adliExecutionIndex"],
+                "adliValue": value["adliValue"]
             }
 
             logger.info(json.dumps(logInfo))


### PR DESCRIPTION
This PR does two things:

1. It adds the value of the inputs and outputs to the logged statements. This is useful because when generating the system level traces, this will allow us to track the data using the log file

Example Input:
```
{
  "type": "adli_input",
  "adliExecutionId": "8c70da36-3a3d-4fb4-a643-2af9094b1605",
  "adliExecutionIndex": 4452,
  "adliValue": {
    "code": 3,
    "worker": true,
    "type": "bubbleSort",
    "value": [24,29,31,40,50,62,74,86,87,91,95],
    "asp_uid": "3e573605-fcb4-496f-9fba-cce554212b09",
    "user": "user1"
  }
}

```
Example Output:
```
{
  "type": "adli_output",
  "outputName": "response",
  "adliExecutionId": "df1ec101-33f2-4767-9f1a-dca69fc25def",
  "adliExecutionIndex": 14931,
  "adliValue": {
    "code": 3,
    "worker": true,
    "type": "radixSort",
    "value": [29,52,62,69,78],
    "asp_uid": "18b7fc01-37c3-41b4-b2a9-00a531509ed2",
    "user": "user5"
  }
}
```

2. For each entry in the log type map, the log statement is now added. This is helpful for debugging but it is ultimately not needed.

Example LtInfo with the added statement:
```
{
      "id": 19,
      "funcid": 15,
      "lineno": 58,
      "end_lineno": 58,
      "type": "child",
      "isUnique": false,
      "statement": "client = websocket"
}
```

## Validation Performed

Logs were injected into the sample system using the command:

`python3 adli_system.py https://github.com/vishalpalaniappan/sample-system.git`

The system was run and the generated logs were inspected to verify the following:
- The log type maps had the statements in each node.
- The input and output logs contain the value of the input and output.

Logged Output:
```
{
  "type": "adli_input",
  "adliExecutionId": "bd307730-a03c-4d2c-8f0b-9c42d263734c",
  "adliExecutionIndex": 3550,
  "adliValue": {
    "code": 3,
    "worker": true,
    "type": "radixSort",
    "value": [6,16,24,26,43,52,59,64,81,83,85,95],
    "asp_uid": "0cd028ec-7ba3-400e-81aa-130e6c3d105f",
    "user": "user5"
  }
}
```

LtInfo Map:
```
{
      "id": 8,
      "funcid": 0,
      "lineno": 22,
      "end_lineno": 26,
      "type": "child",
      "isUnique": false,
      "statement": "MSG_TYPE = {'REGISTER': 1, 'REQUEST': 2, 'RESPONSE': 3}"
}
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Log entries now include a snapshot of the relevant code statement for each log type, improving traceability.
  - Logged metadata for both outputs and inputs now explicitly records the associated variable value, providing more detailed logging information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->