### PR TITLE
Add feature to uniquely identify threads.

### DIFF
--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -35,7 +35,7 @@ class AdliLogger:
         self.outputCount = 0
 
 
-    def getCoroutineId(self):
+    def getTaskId(self):
         try:
             asyncio.get_running_loop()
             current_task = asyncio.current_task()
@@ -87,7 +87,7 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": self.getCoroutineId(),
+                "coroutine": self.getTaskId(),
                 "value": adliValue
             }
             logger.info(varObj)
@@ -97,7 +97,7 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": self.getCoroutineId(),
+                "coroutine": self.getTaskId(),
                 "value": str(value),
                 "serialization_error": str(e)
             }
@@ -117,7 +117,7 @@ class AdliLogger:
         stmtObj = {
             "type": "adli_execution",
             "thread": threading.get_ident(),
-            "coroutine": self.getCoroutineId(),
+            "coroutine": self.getTaskId(),
             "value": stmtId
         }
         logger.info(stmtObj)
@@ -131,7 +131,7 @@ class AdliLogger:
         exceptionObj = {
             "type": "adli_exception",
             "thread": threading.get_ident(),
-            "coroutine": self.getCoroutineId(),
+            "coroutine": self.getTaskId(),
             "value": traceback.format_exc()
         }
         logger.info(exceptionObj)
@@ -155,7 +155,7 @@ class AdliLogger:
         logInfo = {
             "type": "adli_header",
             "thread": threading.get_ident(),
-            "coroutine": self.getCoroutineId(),
+            "coroutine": self.getTaskId(),
             "header": json.dumps(header)
         }
         logger.info(logInfo)
@@ -174,7 +174,7 @@ class AdliLogger:
             "type": "adli_output",
             "outputName": variableName,
             "thread": threading.get_ident(),
-            "coroutine": self.getCoroutineId(),
+            "coroutine": self.getTaskId(),
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliExecutionIndex": self.count + 1,
             "adliValue": value
@@ -203,7 +203,7 @@ class AdliLogger:
             logInfo = {
                 "type": "adli_input",
                 "thread": threading.get_ident(),
-                "coroutine": self.getCoroutineId(),
+                "coroutine": self.getTaskId(),
                 "adliExecutionId": value["adliExecutionId"],
                 "adliExecutionIndex": value["adliExecutionIndex"],
                 "adliValue": value["adliValue"]

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -4,7 +4,6 @@ from clp_logging.handlers import ClpKeyValuePairStreamHandler
 
 import traceback
 import threading
-import asyncio
 import json
 import time
 import os

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -34,15 +34,6 @@ class AdliLogger:
         self.inputCount = 0
         self.outputCount = 0
 
-
-    def getTaskId(self):
-        try:
-            asyncio.get_running_loop()
-            current_task = asyncio.current_task()
-            return current_task.get_name() if current_task else None
-        except RuntimeError:
-            return None
-
     def processLevel(self, o, k, depth, max_depth):
         if isinstance(o, (str, int, float, bool)) or o is None:
             return o
@@ -87,7 +78,6 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": self.getTaskId(),
                 "value": adliValue
             }
             logger.info(varObj)
@@ -97,7 +87,6 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": self.getTaskId(),
                 "value": str(value),
                 "serialization_error": str(e)
             }
@@ -117,7 +106,6 @@ class AdliLogger:
         stmtObj = {
             "type": "adli_execution",
             "thread": threading.get_ident(),
-            "coroutine": self.getTaskId(),
             "value": stmtId
         }
         logger.info(stmtObj)
@@ -131,7 +119,6 @@ class AdliLogger:
         exceptionObj = {
             "type": "adli_exception",
             "thread": threading.get_ident(),
-            "coroutine": self.getTaskId(),
             "value": traceback.format_exc()
         }
         logger.info(exceptionObj)
@@ -155,7 +142,6 @@ class AdliLogger:
         logInfo = {
             "type": "adli_header",
             "thread": threading.get_ident(),
-            "coroutine": self.getTaskId(),
             "header": json.dumps(header)
         }
         logger.info(logInfo)
@@ -174,7 +160,6 @@ class AdliLogger:
             "type": "adli_output",
             "outputName": variableName,
             "thread": threading.get_ident(),
-            "coroutine": self.getTaskId(),
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliExecutionIndex": self.count + 1,
             "adliValue": value
@@ -203,7 +188,6 @@ class AdliLogger:
             logInfo = {
                 "type": "adli_input",
                 "thread": threading.get_ident(),
-                "coroutine": self.getTaskId(),
                 "adliExecutionId": value["adliExecutionId"],
                 "adliExecutionIndex": value["adliExecutionIndex"],
                 "adliValue": value["adliValue"]

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -38,7 +38,8 @@ class AdliLogger:
     def getCoroutineId(self):
         try:
             asyncio.get_running_loop()
-            return asyncio.current_task().get_name()
+            current_task = asyncio.current_task()
+            return current_task.get_name() if current_task else None
         except RuntimeError:
             return None
 


### PR DESCRIPTION
This PR extends the runtime logs to include information about the thread which generated the log. 

## Threads
When injecting logs into programs with multiple threads, we need to be able to uniquely identify statements which belong to a thread to accurately extract the call stack and variable values. To do this, when generating the run time logs, the identity of the current thread is logged along with the rest of the message. For example, here is how statements are logged:

```
stmtObj = {
            "type": "adli_execution",
            "thread": threading.get_ident(),
            "value": stmtId
        }
```

and in the log file, here is an example of the generated log

```
{
    "thread": 140062402447168,
    "type": "adli_execution",
    "value": 50,
    "timestamp": {
        "unix_millisecs": 1748304796824,
        "utc_offset_secs": -14400
    },
    "level": {
        "name": "INFO",
        "num": 20
    }
}
```
## Validation Performed

Diagnostic logs were injected into the threads example [program](https://github.com/vishalpalaniappan/threads-coroutines-experiments/blob/main/threads_example/example2/example2.py).

The program was executed and the generated log was inspected to verify that the threads were uniquely identified. 

The generated log file is provided below:
[c3a9c926-d875-4906-9155-c43ed18aa465.clp.zip](https://github.com/user-attachments/files/20447930/c3a9c926-d875-4906-9155-c43ed18aa465.clp.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Log entries now include the current thread identifier, improving traceability in concurrent environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->