### PR TITLE
Add support for coroutines using new approach. 

### DIFF
--- a/injector/LogInjector.py
+++ b/injector/LogInjector.py
@@ -114,8 +114,6 @@ class LogInjector(ast.NodeTransformer):
         return preLog + [node]
     
     def visit_AsyncFunctionDef(self, node):
-        decorator = ast.Name(id="track_coroutine", ctx=ast.Load())
-        node.decorator_list.insert(0, decorator)
         return self.visit_FunctionDef(node)
 
     def visit_Assign(self, node):

--- a/injector/LoggerInstance/AdliLogger.py
+++ b/injector/LoggerInstance/AdliLogger.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from functools import wraps
 from clp_logging.handlers import ClpKeyValuePairStreamHandler
 
 import traceback
@@ -9,8 +8,6 @@ import json
 import time
 import os
 import uuid
-import contextvars
-import asyncio
 
 ADLI_EXECUTION_ID = str(uuid.uuid4())
 
@@ -19,40 +16,6 @@ clp_handler = ClpKeyValuePairStreamHandler(open(path, "wb"))
 logger = logging.getLogger("adli")
 logger.setLevel(logging.INFO)
 logger.addHandler(clp_handler)
-
-coroutine_id = contextvars.ContextVar("coroutine_id", default=None) 
-
-def track_coroutine(fn):
-    '''
-        This function wraps coroutines using a decorator and assigns
-        a UID to each coroutine. When a coroutine makes a function call,
-        the uid is preserved in the function that is called, allowing
-        us to chain function calls made by coroutines.
-    '''
-    @wraps(fn)
-    async def wrapper(*args, **kwargs):
-        token = None
-        if coroutine_id.get() is None:
-            uid = str(uuid.uuid4())
-            token = coroutine_id.set(uid)
-        try:
-            return await fn(*args, **kwargs)
-        finally:
-            if token:
-                coroutine_id.reset(token)
-    return wrapper
-
-def getTaskId():
-    '''
-        This function returns the name of the task that is
-        currently being executed (if there is one).
-    '''
-    try:
-        asyncio.get_running_loop()
-        current_task = asyncio.current_task()
-        return current_task.get_name() if current_task else None
-    except RuntimeError:
-        return None
 
 class AdliLogger:
     '''
@@ -114,8 +77,6 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": coroutine_id.get(),
-                "task": getTaskId(),
                 "value": adliValue
             }
             logger.info(varObj)
@@ -125,8 +86,6 @@ class AdliLogger:
                 "type": "adli_variable",
                 "varid": varid,
                 "thread": threading.get_ident(),
-                "coroutine": coroutine_id.get(),
-                "task": getTaskId(),
                 "value": str(value),
                 "serialization_error": str(e)
             }
@@ -146,8 +105,6 @@ class AdliLogger:
         stmtObj = {
             "type": "adli_execution",
             "thread": threading.get_ident(),
-            "coroutine": coroutine_id.get(),
-            "task": getTaskId(),
             "value": stmtId
         }
         logger.info(stmtObj)
@@ -161,8 +118,6 @@ class AdliLogger:
         exceptionObj = {
             "type": "adli_exception",
             "thread": threading.get_ident(),
-            "coroutine": coroutine_id.get(),
-            "task": getTaskId(),
             "value": traceback.format_exc()
         }
         logger.info(exceptionObj)
@@ -186,8 +141,6 @@ class AdliLogger:
         logInfo = {
             "type": "adli_header",
             "thread": threading.get_ident(),
-            "coroutine": coroutine_id.get(),
-            "task": getTaskId(),
             "header": json.dumps(header)
         }
         logger.info(logInfo)
@@ -206,8 +159,6 @@ class AdliLogger:
             "type": "adli_output",
             "outputName": variableName,
             "thread": threading.get_ident(),
-            "coroutine": coroutine_id.get(),
-            "task": getTaskId(),
             "adliExecutionId": ADLI_EXECUTION_ID,
             "adliExecutionIndex": self.count + 1,
             "adliValue": value
@@ -236,8 +187,6 @@ class AdliLogger:
             logInfo = {
                 "type": "adli_input",
                 "thread": threading.get_ident(),
-                "coroutine": coroutine_id.get(),
-                "task": getTaskId(),
                 "adliExecutionId": value["adliExecutionId"],
                 "adliExecutionIndex": value["adliExecutionIndex"],
                 "adliValue": value["adliValue"]


### PR DESCRIPTION
PR #68 added support for uniquely identifying coroutines so that unique stack frames can be extracted. However, after some more thinking, the approach that it took is not ideal. It relies on information from specific frameworks instead of taking an framework agnostic approach to solve the problem. In addition, the approach of using contextvars does not work because it requires the decorator to only be added at the start of a coroutine (this will inevitably require user intervention, which is not ideal). 

This PR uses a cleaner approach to solve this problem. More details coming soon.