### PR TITLE
Fix the constraints in v1 of library manager.

### DIFF
--- a/sample/library_manager_v1/library_manager_meta.json
+++ b/sample/library_manager_v1/library_manager_meta.json
@@ -105,6 +105,7 @@
         "intent": "Prompt and accept book name",
         "constraint": [
             {
+                "id": "2-2+1",
                 "name": "name",
                 "scope": "local",
                 "type":"minLength",
@@ -144,23 +145,15 @@
         "intent": "Create the bookshelf.",
         "constraint": [
             {
+                "id": "3-1+1",
                 "name": "book_shelf",
                 "scope": "local",
                 "type":"is_object",
                 "value": "object",
-                "failures": ["1-3-1"],
+                "failures": ["1-3", "1-3-1"],
                 "rootcause": {
+                    "1-3": "The root cause of failure was that the bookshelf was never initialized as an object with the intention of checking to see if a key exists in it for placing the books in the relevant slot. This resulted in a failure when attempting to check if a slot exists for the firstLetter on the bookshelf because the in operator requires an iterable.",
                     "1-3-1": "The root cause of failure was that the bookshelf was never initialized as an object, despite the design intending to use it as a keyed storage abstraction for placing books into slots, which caused the program to fail when it attempted to create a slot for a book."
-                }
-            },
-            {
-                "name": "book_shelf",
-                "scope": "local",
-                "type":"is_not_null",
-                "value": "object",
-                "failures": ["1-3"],
-                "rootcause": {
-                    "1-3": "The root cause of failure was that the bookshelf was initialized as None with the intention of checking to see if a key exists in it for placing the books in the relevant slot. This resulted in a failure when attempting to check if a slot exists for the firstLetter on the bookshelf because the in operator requires an iterable and the bookshelf was None."
                 }
             }
         ]


### PR DESCRIPTION
This PR fixes the constraint instrumentation of library manager v1. 

More specifically, rather than check if the book shelf is null, it just validates that the book shelf is an object. The two failure modalities that result from this are instrumented into the constraint. 

It also adds an ID to the constraint because that was introduced in the previous PR with library manager v2. 

Updated constraint for the bookshelf:
```
{
    "id": "3-1+1",
    "name": "book_shelf",
    "scope": "local",
    "type":"is_object",
    "value": "object",
    "failures": ["1-3", "1-3-1"],
    "rootcause": {
        "1-3": "The root cause of failure was that the bookshelf was never initialized as an object with the intention of checking to see if a key exists in it for placing the books in the relevant slot. This resulted in a failure when attempting to check if a slot exists for the firstLetter on the bookshelf because the in operator requires an iterable.",
        "1-3-1": "The root cause of failure was that the bookshelf was never initialized as an object, despite the design intending to use it as a keyed storage abstraction for placing books into slots, which caused the program to fail when it attempted to create a slot for a book."
    }
}
```

## Validation Performed

Generated a trace file where bookshelf was initialized as None to verify that the constraint violation was capture and that the root cause was correctly identified when the failure happened.
[demo_shelf_none_failure.clp.zip](https://github.com/user-attachments/files/24098524/demo_shelf_none_failure.clp.zip)

Link:
https://vishalpalaniappan.github.io/diagnostic-log-viewer/?filePath=https://diagnostic-logs-sample.s3.us-east-2.amazonaws.com/demo_shelf_none_failure.clp.zst

If link becomes outdated, it can be opened with this commit of the trace viewer:
https://github.com/vishalpalaniappan/diagnostic-log-viewer/commit/4253e9f65408134e3bf522136388399d0934ad2d
